### PR TITLE
feat: added banner and update subscription check to make maintained actions free for public repos

### DIFF
--- a/.github/workflows/actions_release.yml
+++ b/.github/workflows/actions_release.yml
@@ -6,6 +6,10 @@ on:
       tag:
         description: "Tag for the release"
         required: true
+      node_version:
+        description: "Specify Node.js version (e.g., '18', '20', 'lts/*')"
+        required: false
+        default: "24"
 permissions:
   contents: read
 
@@ -19,3 +23,4 @@ jobs:
     uses: step-security/reusable-workflows/.github/workflows/actions_release.yaml@v1
     with:
       tag: "${{ github.event.inputs.tag }}"
+      node_version: "${{ github.event.inputs.node_version }}"

--- a/.github/workflows/audit_package.yml
+++ b/.github/workflows/audit_package.yml
@@ -11,6 +11,10 @@ on:
         description: "Specify a base branch"
         required: false
         default: "main"
+      node_version:
+        description: "Specify Node.js version (e.g., '18', '20', 'lts/*')"
+        required: false
+        default: "24"
   schedule:
     - cron: "0 0 * * 1"
 
@@ -20,6 +24,7 @@ jobs:
     with:
       force: ${{ inputs.force || false }}
       base_branch: ${{ inputs.base_branch || 'main' }}
+      node_version: "${{ inputs.node_version || '24' }}"
 
 permissions:
   contents: write

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![StepSecurity Maintained Action](https://raw.githubusercontent.com/step-security/maintained-actions-assets/main/assets/maintained-action-banner.png)](https://docs.stepsecurity.io/actions/stepsecurity-maintained-actions)
+
 # Setup starknet-class-hash action
 
 Downloads and installs the starknet-class-hash CLI tool for use in GitHub Actions workflows.

--- a/action.yml
+++ b/action.yml
@@ -6,5 +6,5 @@ inputs:
     description: Version of starknet-class-hash to install (e.g., '0.1.0' or 'v0.1.0')
     required: true
 runs:
-  using: "node20"
+  using: "node24"
   main: "dist/index.js"

--- a/dist/index.js
+++ b/dist/index.js
@@ -69435,6 +69435,9 @@ var __webpack_exports__ = {};
 var core = __nccwpck_require__(7484);
 // EXTERNAL MODULE: ./node_modules/@actions/tool-cache/lib/tool-cache.js
 var tool_cache = __nccwpck_require__(3472);
+// EXTERNAL MODULE: external "fs"
+var external_fs_ = __nccwpck_require__(9896);
+var external_fs_default = /*#__PURE__*/__nccwpck_require__.n(external_fs_);
 // EXTERNAL MODULE: external "os"
 var external_os_ = __nccwpck_require__(857);
 var external_os_default = /*#__PURE__*/__nccwpck_require__.n(external_os_);
@@ -69531,22 +69534,52 @@ async function locateInnerDirectory(parentPath) {
 
 
 
+
 const axios = __nccwpck_require__(7269)
 
 async function validateSubscription() {
-  const API_URL = `https://agent.api.stepsecurity.io/v1/github/${process.env.GITHUB_REPOSITORY}/actions/subscription`
+  let repoPrivate;
+  const eventPath = process.env.GITHUB_EVENT_PATH;
+  if (eventPath && external_fs_default().existsSync(eventPath)) {
+    const payload = JSON.parse(external_fs_default().readFileSync(eventPath, "utf8"));
+    repoPrivate = payload?.repository?.private;
+  }
 
+  const upstream = "ericnordelo/starknet-class-hash";
+  const action = process.env.GITHUB_ACTION_REPOSITORY;
+  const docsUrl =
+    "https://docs.stepsecurity.io/actions/stepsecurity-maintained-actions";
+
+  core.info("");
+  core.info("[1;36mStepSecurity Maintained Action[0m");
+  core.info(`Secure drop-in replacement for ${upstream}`);
+  if (repoPrivate === false)
+    core.info("[32m✓ Free for public repositories[0m");
+  core.info(`[36mLearn more:[0m ${docsUrl}`);
+  core.info("");
+
+  if (repoPrivate === false) return;
+  const serverUrl = process.env.GITHUB_SERVER_URL || "https://github.com";
+  const body = { action: action || "" };
+
+  if (serverUrl !== "https://github.com") body.ghes_server = serverUrl;
   try {
-    await axios.get(API_URL, {timeout: 3000})
+    await axios.post(
+      `https://agent.api.stepsecurity.io/v1/github/${process.env.GITHUB_REPOSITORY}/actions/maintained-actions-subscription`,
+      body,
+      { timeout: 3000 },
+    );
   } catch (error) {
-    if (error.response && error.response.status === 403) {
+    if (axios.isAxiosError(error) && error.response?.status === 403) {
       core.error(
-        'Subscription is not valid. Reach out to support@stepsecurity.io'
-      )
-      process.exit(1)
-    } else {
-      core.info('Timeout or API not reachable. Continuing to next step.')
+        `[1;31mThis action requires a StepSecurity subscription for private repositories.[0m`,
+      );
+      core.error(
+        `[31mLearn how to enable a subscription: ${docsUrl}[0m`,
+      );
+      process.exit(1);
     }
+    core.info("Timeout or API not reachable. Continuing to next step.");
   }
 }
 

--- a/src/run.js
+++ b/src/run.js
@@ -1,5 +1,6 @@
 import * as core from "@actions/core";
 import * as tc from "@actions/tool-cache";
+import fs from "fs";
 import {
   determineVersion,
   versionWithPrefix,
@@ -9,19 +10,48 @@ import {
 const axios = require("axios")
 
 async function validateSubscription() {
-  const API_URL = `https://agent.api.stepsecurity.io/v1/github/${process.env.GITHUB_REPOSITORY}/actions/subscription`
+  let repoPrivate;
+  const eventPath = process.env.GITHUB_EVENT_PATH;
+  if (eventPath && fs.existsSync(eventPath)) {
+    const payload = JSON.parse(fs.readFileSync(eventPath, "utf8"));
+    repoPrivate = payload?.repository?.private;
+  }
 
+  const upstream = "ericnordelo/starknet-class-hash";
+  const action = process.env.GITHUB_ACTION_REPOSITORY;
+  const docsUrl =
+    "https://docs.stepsecurity.io/actions/stepsecurity-maintained-actions";
+
+  core.info("");
+  core.info("[1;36mStepSecurity Maintained Action[0m");
+  core.info(`Secure drop-in replacement for ${upstream}`);
+  if (repoPrivate === false)
+    core.info("[32m✓ Free for public repositories[0m");
+  core.info(`[36mLearn more:[0m ${docsUrl}`);
+  core.info("");
+
+  if (repoPrivate === false) return;
+  const serverUrl = process.env.GITHUB_SERVER_URL || "https://github.com";
+  const body = { action: action || "" };
+
+  if (serverUrl !== "https://github.com") body.ghes_server = serverUrl;
   try {
-    await axios.get(API_URL, {timeout: 3000})
+    await axios.post(
+      `https://agent.api.stepsecurity.io/v1/github/${process.env.GITHUB_REPOSITORY}/actions/maintained-actions-subscription`,
+      body,
+      { timeout: 3000 },
+    );
   } catch (error) {
-    if (error.response && error.response.status === 403) {
+    if (axios.isAxiosError(error) && error.response?.status === 403) {
       core.error(
-        'Subscription is not valid. Reach out to support@stepsecurity.io'
-      )
-      process.exit(1)
-    } else {
-      core.info('Timeout or API not reachable. Continuing to next step.')
+        `[1;31mThis action requires a StepSecurity subscription for private repositories.[0m`,
+      );
+      core.error(
+        `[31mLearn how to enable a subscription: ${docsUrl}[0m`,
+      );
+      process.exit(1);
     }
+    core.info("Timeout or API not reachable. Continuing to next step.");
   }
 }
 


### PR DESCRIPTION
## Summary

- Added StepSecurity Maintained Action banner to README.md
- Updated subscription validation: public repositories are now free (no API check)
- Upgraded Node.js runtime to node24 (if applicable)
- Updated workflow files with configurable node_version input (if applicable)

## Changes by type
- **TypeScript/JS actions**: replaced `validateSubscription()` body, updated action.yml to node24, updated 3 workflow files, rebuilt dist/
- **Docker actions**: replaced entrypoint.sh subscription block, ensured jq is installed in Dockerfile
- **Composite actions**: added Subscription check step to action.yml

## Verification
- [ ] Subscription check skips for public repos
- [ ] Subscription check fires for private repos
- [ ] README banner is present at the top
- [ ] Build passes (TS/JS actions)

Auto-generated by StepSecurity update-propagator. Task ID: 20260423T092801Z